### PR TITLE
fix: variables/git

### DIFF
--- a/variables/git.md
+++ b/variables/git.md
@@ -1,7 +1,7 @@
 ---
-title: Git情報変数
-linktitle: Git Variables
-description: コンテンツファイル毎の最新Gitリビジョンの情報を取得します。
+title: Git 情報変数
+linktitle: Git 変数
+description: コンテンツファイル毎の最新 Git リビジョン情報を取得します。
 date: 2017-03-12
 publishdate: 2017-03-12
 lastmod: 2017-03-12

--- a/variables/git.md
+++ b/variables/git.md
@@ -20,7 +20,7 @@ wip: false
 ---
 
 {{% note "`.GitInfo` Performance Considerations"  %}}
-Hugo の Git 統合はかなりパフォーマンスが良いはずですが、ビルド時間が長くなる*かも*しれません。これは Git の履歴サイズによります。
+Hugo の Git 統合はかなりパフォーマンスが良いはずですが、ビルド時間が長くなる *かも* しれません。これは Git の履歴サイズによります。
 {{% /note %}}
 
 ## `.GitInfo` の必要条件

--- a/variables/git.md
+++ b/variables/git.md
@@ -23,11 +23,11 @@ wip: false
 Hugo の Git 統合はかなりパフォーマンスが良いはずですが、ビルド時間が長くなる*かも*しれません。これは Git の履歴サイズによります。
 {{% /note %}}
 
-## `.GitInfo` の必須要件
+## `.GitInfo` の必要条件
 
-1. Hugo サイトが Git が有効化されたディレクトリー内にあること
-2. Git がインストールされており、システムの `PATH` が通っていること
-3. Hugo プロジェクトの`.GitInfo` が有効になっていること。コマンドラインで`--enableGitInfo` フラグをつけるか、[サイトの設定ファイル][configuration]に `enableGitInfo` を `true` で設定することで有効にできます
+1. Hugo サイトが Git の有効化されたディレクトリー内にあること。
+2. Git がインストールされており、システムの `PATH` が通っていること。
+3. Hugo プロジェクトにおいて `.GitInfo` が有効になっていること。コマンドラインで `--enableGitInfo` フラグをつけるか、[サイトの設定ファイル][configuration]において `enableGitInfo` に `true` を指定することで有効にできます。
 
 ## `.GitInfo` オブジェクト
 

--- a/variables/git.md
+++ b/variables/git.md
@@ -53,6 +53,6 @@ Hugo の Git 統合はかなりパフォーマンスが良いはずですが、�
 
 ## `.Lastmod`
 
-`.GitInfo` 機能が有効になっている場合、（`Page` の）`.Lastmod` は Git の、例えば`.GitInfo.AuthorDate` から取得されます。この挙動は[日付のフロントマター設定](/getting-started/configuration/#configure-front-matter)を追加することで変更できます。
+`.GitInfo` 機能が有効になっている場合、（`Page` の）`.Lastmod` は Git の、例えば `.GitInfo.AuthorDate` から取得されます。この挙動は[日付の front matter 設定](/getting-started/configuration/#configure-front-matter)を追加することで変更できます。
 
 [configuration]: /getting-started/configuration/


### PR DESCRIPTION
#28 におけるリンクタイトルの翻訳忘れなどを修正。